### PR TITLE
Web Viewer - fix distribution ID validation

### DIFF
--- a/output-management/web-viewer/downloader/application/src/main/java/com/broadcom/msd/om/sample/downloader/controllers/Download.java
+++ b/output-management/web-viewer/downloader/application/src/main/java/com/broadcom/msd/om/sample/downloader/controllers/Download.java
@@ -261,7 +261,7 @@ public class Download extends Common implements Initializable {
     }
 
     final String distribution = distributionId.get();
-    if (distribution == null || distribution.isEmpty() || distribution.length() > 8) {
+    if (distribution == null || distribution.isEmpty() || distribution.length() > 32) {
       return false;
     }
 

--- a/output-management/web-viewer/favorites/README.md
+++ b/output-management/web-viewer/favorites/README.md
@@ -81,8 +81,8 @@ Other OS:
     npm run generate-sdk
     ./gradlew run
 
-### Login 
+### Login
 
 1. Enter the URL and confirm with "OK" to activate the application wizard.
- URL example: `http://<HOSTNAME>:<PORT>/web-viewer`
+   URL example: `http://<HOSTNAME>:<PORT>/web-viewer`
 2. Provide your login credential to launch **"Web Viewer - Favorites" Wizard.

--- a/output-management/web-viewer/favorites/README.md
+++ b/output-management/web-viewer/favorites/README.md
@@ -80,3 +80,9 @@ Other OS:
 
     npm run generate-sdk
     ./gradlew run
+
+### Login 
+
+1. Enter the URL and confirm with "OK" to activate the application wizard.
+ URL example: `http://<HOSTNAME>:<PORT>/web-viewer`
+2. Provide your login credential to launch **"Web Viewer - Favorites" Wizard.

--- a/output-management/web-viewer/favorites/favorites/src/main/java/com/broadcom/msd/om/sample/favorites/controllers/DefineFavorite.java
+++ b/output-management/web-viewer/favorites/favorites/src/main/java/com/broadcom/msd/om/sample/favorites/controllers/DefineFavorite.java
@@ -210,7 +210,7 @@ public class DefineFavorite extends Common implements Initializable {
   private boolean isDistributionValid() {
     final String distribution = getDistributionId();
 
-    if (distribution == null || distribution.isEmpty() || distribution.length() > 8) {
+    if (distribution == null || distribution.isEmpty() || distribution.length() > 32) {
       return false;
     }
 


### PR DESCRIPTION
**Description of changes**
[D557884](https://rally1.rallydev.com/#/?detail=/defect/685148220573&fdp=true): Distribution ID length limit validation is wrong in samples

**QA Recommendation / Unit Testing Details.** 

```
On the Web Viewer - Favorites Window: 

- Create a new favorite by providing valid inputs. 
1.     Choose repo for example : XYZ PRODUCTION 
2.     Choose Mode EXP
3.     Try giving DIST ID of 32 characters. "PMFKEYPMFKEYPMFKEYPMFKEYPMFKEY00" the box is still green so valid.
4.     Try giving DIST ID of 33 characters. "PMFKEYPMFKEYPMFKEYPMFKEYPMFKEY00A" the box is now red so invalid.
5.     Now with valid entry, Back to Web Viewer - Favorites 
6.     Click Edit on any active 
7.     Check the same on this. 

               --------10--------20--------30--
LENGTH       : 12345678901234567890123456789012
VALID DISTID : PMFKEYPMFKEYPMFKEYPMFKEYPMFKEY00  <GREEN> 
INVALID ID   : PMFKEYPMFKEYPMFKEYPMFKEYPMFKEY00A <RED>

On the Download Reports Window: 

1.     Choose repo for example : XYZ PRODUCTION 
2.     Choose Mode EXP
3.     Try giving DIST ID of 32 characters. "PMFKEYPMFKEYPMFKEYPMFKEYPMFKEY00" the box is still green so valid.
4.     Try giving DIST ID of 33 characters. "PMFKEYPMFKEYPMFKEYPMFKEYPMFKEY00A" the box is now red so invalid.
5.     Provide valid archival dates and other input to preview/download the reports. 

```