### PR TITLE
Add workflow to scan build.gradle deps

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,39 @@
+name: Submit Gradle Dependency Graph
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        project-dir:
+          - './output-management/web-viewer/favorites'
+          - './output-management/web-viewer/favorites/favorites'
+          - './output-management/web-viewer/downloader'
+          - './output-management/web-viewer/downloader/application'
+          - './output-management/web-viewer/api-basics/java'
+          - './share/2022_columbus/AtoZ/email-spring-boot'
+          
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Submit Dependency Graph for ${{ matrix.project-dir }}
+        uses: gradle/actions/dependency-submission@v3
+        with:
+          gradle-version: '7.6.6'
+          build-root-directory: ${{ matrix.project-dir }}

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -2,3 +2,4 @@ example.com
 npmjs.com
 medium.com
 mvnrepository.com
+ibm.com


### PR DESCRIPTION
<!-- PR Requirements

- Sensitive data policy
Please ensure that your PR does not include proprietary/sensitive information such as user IDs, system names (we suggest using generic names for LPARS such as MF01, MF02, etc.), system URLs/IP addresses, or port numbers (unless the port numbers are default values like 443 for z/OSMF or 22 for SSH).

- Documentation
Please review READMEs with a technical writer before creating a pull request.

- Submitter responsibilities regarding detected vulnerabilities
This repository is scanned automatically by Dependabot. If a vulnerability is detected within a contribution, the original contributor will be contacted and asked to resolve the vulnerability. Contributors will have 30 days from the date when they are first notified of a detected vulnerability to submit a pull request that resolves the vulnerability. If the vulnerability has not been resolved within this 30-day period, the vulnerable script, project, or application will be removed from the repository. 

By submitting a pull request to this repository, the contributor agrees to abide by these terms.-->

**Description of changes**
Adds a workflow that scans known build.gradle files on pushes to main, adding dependencies to the dependency graph.
